### PR TITLE
Ensure tokenizer padding is enforced

### DIFF
--- a/safe/models/safe_model.py
+++ b/safe/models/safe_model.py
@@ -464,6 +464,10 @@ class SAFEModel(nn.Module):
         Returns:
             Dictionary with input_ids, attention_mask, audio_tokens, etc.
         """
+        # Ensure tokenizer padding configuration remains correct before encoding
+        if self.base_vl.ensure_left_padding():
+            print("[SAFEModel] Re-applied left padding configuration before multimodal prep", flush=True)
+
         # For LLaVA/BLIP2, use proper multimodal input preparation
         if self.base_vl.model_type == "llava":
             # LLaVA-specific handling with chat templates and proper <image> token insertion


### PR DESCRIPTION
## Summary
- add helper utilities to force all tokenizer instances to use left padding when working with decoder-only language models
- re-apply the padding safeguard before every multimodal/text tokenization step so downstream calls cannot silently flip back to right padding

## Testing
- pytest *(fails: interrupted due to heavyweight optional dependencies triggered during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a93e530c832a9b3cb76a38caac61