### PR TITLE
Fix audio generation slicing for evaluation

### DIFF
--- a/safe/training/stage_a.py
+++ b/safe/training/stage_a.py
@@ -2230,19 +2230,27 @@ class StageATrainer:
                                        dtype=torch.long, device=generated.device)
 
         audio_prefix = audio_tokens.size(1) if isinstance(audio_tokens, torch.Tensor) else 0
-        
+
         if self.debug_logging:
             print(f"[GenDebug] Generated shape: {generated.shape}", flush=True)
             print(f"[GenDebug] Audio prefix: {audio_prefix}", flush=True)
             print(f"[GenDebug] Per-sample prompt lengths: {prompt_lengths.tolist()}", flush=True)
-        
+
         # Extract only the newly generated tokens (after prompt) using per-sample lengths
         extracted_tokens = []
         for i in range(generated.size(0)):
             # Use per-sample prompt length to handle left padding correctly
             sample_prompt_len = prompt_lengths[i].item()
-            start_idx = audio_prefix + sample_prompt_len
-            
+
+            # When audio tokens are prefixed via inputs_embeds the attention mask already
+            # accounts for them. Subtract the audio prefix so we only skip the textual
+            # portion of the prompt when slicing generated tokens. Clamp at zero in case the
+            # audio prefix is larger than the prompt length due to padding edge cases.
+            if audio_prefix > 0:
+                sample_prompt_len = max(0, sample_prompt_len - audio_prefix)
+
+            start_idx = sample_prompt_len
+
             if start_idx < generated.shape[1]:
                 new_tokens = generated[i, start_idx:]
                 if self.debug_logging:


### PR DESCRIPTION
## Summary
- adjust robust accuracy generation token slicing to avoid double-counting audio prefixes
- ensure extracted predictions are not empty when audio tokens are prefixed via inputs_embeds

## Testing
- pytest -k generate_predictions --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68d46b0efe88832a8e8c8700c3f63203