### PR TITLE
Add full-scale training experiment scaffolding

### DIFF
--- a/experiments/full_training/README.md
+++ b/experiments/full_training/README.md
@@ -1,0 +1,55 @@
+# Full-Scale Stage A Training
+
+This directory captures the configuration and utilities for the "100x data"
+follow-up to the original overfitting ablation.  Instead of the packaged
+400-clip subset we now rely on the full AudioCaps training split for Stage A and
+use VQA v2 for the vision-language retention evaluation.
+
+## Contents
+
+- `download_data.py` – convenience script for fetching the experiment data pack
+  onto a cluster node.
+- `run_full_training.py` – Python entry-point that wires datasets, model, and
+  retention configuration before delegating to the Stage A trainer.
+- `README.md` – this file.
+
+The helper SBATCH script `scripts/full_training.sh` mirrors
+`scripts/overfitting_test.sh` but targets this experiment.  It loops over the two
+supported retention configurations (`no_retention` and `soft_retention`) so the
+resulting directory contains one run per setting.
+
+## Expected data layout
+
+`download_data.py` extracts the archives into `experiments/full_training/data/`
+by default, producing the following structure that matches the dataset helper
+classes in `safe.data.datasets`:
+
+```
+experiments/full_training/data/
+├── audiocaps/
+│   ├── audiocaps_train.jsonl
+│   ├── audiocaps_val.jsonl
+│   └── audio/...
+└── vqa/
+    ├── vqa_train.jsonl
+    ├── vqa_val.jsonl
+    └── images/val2014/...
+```
+
+You can override the download destination with `--destination` and point the
+runner at any directory that matches this layout via `--data-root`.
+
+## Running the experiment
+
+1. Download or stage the required data pack:
+   ```bash
+   python -m experiments.full_training.download_data --audiocaps-url <URL> --vqa-url <URL>
+   ```
+2. Submit the training job (customise SBATCH resources as needed):
+   ```bash
+   sbatch scripts/full_training.sh
+   ```
+3. Results are written to `experiments/full_training/runs/<timestamp>_<variant>/`.
+
+Each run serialises the exact trainer configuration (`config.json`) and the
+final evaluation metrics (`metrics.json`) to help with downstream analysis.

--- a/experiments/full_training/download_data.py
+++ b/experiments/full_training/download_data.py
@@ -1,0 +1,179 @@
+"""Download helper for the full-scale SAFE Stage A experiment.
+
+The new experiment consumes substantially more data than the overfitting ablation,
+so this script streamlines fetching the pre-packed AudioCaps (training) and VQA
+(validation) assets onto a cluster node.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+CHUNK_SIZE = 1024 * 1024  # 1 MiB
+
+
+def _detect_archive_type(path: Path) -> str:
+    suffixes = ''.join(path.suffixes).lower()
+    if suffixes.endswith('.tar.gz') or suffixes.endswith('.tgz'):
+        return 'tar.gz'
+    if suffixes.endswith('.tar'):
+        return 'tar'
+    if suffixes.endswith('.zip'):
+        return 'zip'
+    raise ValueError(f"Unsupported archive format for '{path}'")
+
+
+def download_file(url: str, destination: Path, *, timeout: int = 30, resume: bool = False) -> Path:
+    """Stream a file from ``url`` into ``destination`` with a progress message."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    headers = {}
+    mode = 'wb'
+    if resume and destination.exists():
+        offset = destination.stat().st_size
+        headers['Range'] = f'bytes={offset}-'
+        mode = 'ab'
+    else:
+        offset = 0
+
+    with requests.get(url, stream=True, timeout=timeout, headers=headers) as response:
+        response.raise_for_status()
+        total = response.headers.get('Content-Length')
+        if total is not None:
+            total = int(total) + offset
+        downloaded = offset
+        print(f"Downloading {url} → {destination} ({'unknown size' if total is None else f'{total/1e6:.1f} MB'})")
+        with open(destination, mode) as fh:
+            for chunk in response.iter_content(CHUNK_SIZE):
+                if chunk:
+                    fh.write(chunk)
+                    downloaded += len(chunk)
+                    if total is not None:
+                        pct = downloaded / total * 100
+                        sys.stdout.write(f"\r  {downloaded/1e6:8.1f} / {total/1e6:8.1f} MB ({pct:5.1f}%)")
+                    else:
+                        sys.stdout.write(f"\r  {downloaded/1e6:8.1f} MB")
+                    sys.stdout.flush()
+        sys.stdout.write("\n")
+    return destination
+
+
+def extract_archive(archive_path: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    archive_type = _detect_archive_type(archive_path)
+    print(f"Extracting {archive_path} into {destination} ({archive_type})")
+    if archive_type in {'tar.gz', 'tar'}:
+        mode = 'r:gz' if archive_type == 'tar.gz' else 'r:'
+        with tarfile.open(archive_path, mode) as tar:
+            tar.extractall(destination)
+    elif archive_type == 'zip':
+        with zipfile.ZipFile(archive_path) as zip_fh:
+            zip_fh.extractall(destination)
+    print("Extraction complete")
+
+
+def validate_dataset_root(root: Path) -> None:
+    audiocaps_dir = root / 'audiocaps'
+    vqa_dir = root / 'vqa'
+    missing = [p for p in (audiocaps_dir, vqa_dir) if not p.exists()]
+    if missing:
+        formatted = ', '.join(str(p) for p in missing)
+        raise FileNotFoundError(
+            f"Expected experiment data to contain both 'audiocaps' and 'vqa' directories. Missing: {formatted}"
+        )
+
+
+def resolve_url(arg_value: Optional[str], env_var: str, description: str) -> str:
+    value = arg_value or os.environ.get(env_var)
+    if not value:
+        raise SystemExit(
+            f"{description} URL not provided. Pass --{description.lower().replace(' ', '-')} or set {env_var}."
+        )
+    return value
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Download full SAFE training data pack")
+    parser.add_argument(
+        "--destination",
+        type=Path,
+        default=Path("experiments/full_training/data"),
+        help="Where to extract the datasets (default: experiments/full_training/data)",
+    )
+    parser.add_argument(
+        "--audiocaps-url",
+        type=str,
+        help="HTTP(S) URL pointing to the AudioCaps archive",
+    )
+    parser.add_argument(
+        "--vqa-url",
+        type=str,
+        help="HTTP(S) URL pointing to the VQA archive",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="HTTP timeout in seconds for each request (default: 60)",
+    )
+    parser.add_argument(
+        "--keep-archives",
+        action="store_true",
+        help="Do not delete the downloaded archive files after extraction",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume partially downloaded archives if present",
+    )
+
+    args = parser.parse_args(argv)
+
+    audiocaps_url = resolve_url(args.audiocaps_url, "SAFE_FULL_AUDIOCAPS_URL", "AudioCaps")
+    vqa_url = resolve_url(args.vqa_url, "SAFE_FULL_VQA_URL", "VQA")
+
+    destination = args.destination.expanduser().resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+
+    archives_dir = destination / "archives"
+    archives_dir.mkdir(exist_ok=True)
+
+    try:
+        audiocaps_archive = download_file(
+            audiocaps_url,
+            archives_dir / Path(audiocaps_url).name,
+            timeout=args.timeout,
+            resume=args.resume,
+        )
+        extract_archive(audiocaps_archive, destination)
+        if not args.keep_archives:
+            audiocaps_archive.unlink(missing_ok=True)
+
+        vqa_archive = download_file(
+            vqa_url,
+            archives_dir / Path(vqa_url).name,
+            timeout=args.timeout,
+            resume=args.resume,
+        )
+        extract_archive(vqa_archive, destination)
+        if not args.keep_archives:
+            vqa_archive.unlink(missing_ok=True)
+
+        validate_dataset_root(destination)
+        print(f"Dataset ready at {destination}")
+        return 0
+    except Exception as exc:
+        print(f"\n[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/full_training/run_full_training.py
+++ b/experiments/full_training/run_full_training.py
@@ -1,0 +1,330 @@
+"""Stage A training driver for the full-scale SAFE experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+from configs.model_configs import DEMO_CONFIG, FULL_CONFIG, MULTIMODAL_CONFIG
+from safe.data.datasets import AudioCapsDataset, VQADataset, create_safe_dataloader
+from safe.models.safe_model import SAFEModel
+from safe.training.stage_a import StageATrainer
+
+
+@dataclass
+class TrainingConfig:
+    variant: str
+    seed: int
+    train_batch_size: int
+    val_batch_size: int
+    num_epochs: int
+    learning_rate_projector: float
+    learning_rate_adapter: float
+    fisher_weight: float
+    retention_loss_weight: float
+    distillation_weight: float
+    enable_null_space: bool
+    null_space_rank: int
+    null_space_min_samples: int
+    null_space_refresh_interval: int
+    output_dir: str
+    max_eval_batches: Optional[int]
+    max_audio_eval_batches: int
+    max_vl_eval_batches: int
+    eval_with_audio_gate: bool
+    eval_audio_gate_comparison: bool
+    eval_logging_steps: int
+    debug_logging: bool
+    train_accuracy_interval: int
+    train_accuracy_warmup: int
+    train_eval_batches: int
+    generation_max_new_tokens: int
+
+
+class CombinedValidationDataset(Dataset):
+    """Mix AudioCaps and VQA examples for joint evaluation."""
+
+    def __init__(
+        self,
+        audio_dataset: Dataset,
+        vl_dataset: Dataset,
+        *,
+        max_audio_samples: Optional[int] = None,
+        max_vl_samples: Optional[int] = None,
+        shuffle: bool = True,
+        seed: int = 42,
+    ) -> None:
+        self.audio_dataset = audio_dataset
+        self.vl_dataset = vl_dataset
+
+        audio_count = len(audio_dataset) if max_audio_samples is None else min(len(audio_dataset), max_audio_samples)
+        vl_count = len(vl_dataset) if max_vl_samples is None else min(len(vl_dataset), max_vl_samples)
+
+        self.index_map: List[Tuple[str, int]] = [
+            ("audio", idx) for idx in range(audio_count)
+        ] + [
+            ("vl", idx) for idx in range(vl_count)
+        ]
+
+        if shuffle:
+            rng = random.Random(seed)
+            rng.shuffle(self.index_map)
+
+    def __len__(self) -> int:
+        return len(self.index_map)
+
+    def __getitem__(self, idx: int):
+        domain, local_idx = self.index_map[idx]
+        if domain == "audio":
+            return self.audio_dataset[local_idx]
+        return self.vl_dataset[local_idx]
+
+
+def set_random_seeds(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def configure_variant(variant: str, base_config: TrainingConfig) -> TrainingConfig:
+    variant = variant.lower()
+    cfg = base_config
+
+    if variant == "no_retention":
+        cfg.retention_loss_weight = 0.0
+        cfg.distillation_weight = 0.0
+        cfg.fisher_weight = 0.0
+        cfg.enable_null_space = False
+    elif variant == "soft_retention":
+        cfg.retention_loss_weight = 0.2
+        cfg.distillation_weight = 0.2
+        cfg.fisher_weight = 0.0
+        cfg.enable_null_space = False
+    else:
+        raise ValueError(f"Unknown variant '{variant}'")
+
+    cfg.variant = variant
+    return cfg
+
+
+def build_stage_a_config(cfg: TrainingConfig) -> Dict[str, object]:
+    max_eval_batches = cfg.max_eval_batches
+    if max_eval_batches is not None and max_eval_batches <= 0:
+        max_eval_batches = None
+
+    return {
+        "learning_rate_projector": cfg.learning_rate_projector,
+        "learning_rate_adapter": cfg.learning_rate_adapter,
+        "num_epochs": cfg.num_epochs,
+        "eval_steps": 5_000,
+        "save_steps": 5_000,
+        "logging_steps": 100,
+        "eval_logging_steps": max(1, cfg.eval_logging_steps),
+        "max_eval_batches": max_eval_batches,
+        "max_audio_eval_batches": cfg.max_audio_eval_batches,
+        "max_vl_eval_batches": cfg.max_vl_eval_batches,
+        "eval_with_audio_gate": cfg.eval_with_audio_gate,
+        "eval_audio_gate_comparison": cfg.eval_audio_gate_comparison,
+        "debug_logging": cfg.debug_logging,
+        "retention_loss_weight": cfg.retention_loss_weight,
+        "distillation_weight": cfg.distillation_weight,
+        "fisher_weight": cfg.fisher_weight,
+        "enable_null_space": cfg.enable_null_space,
+        "null_space_rank": cfg.null_space_rank,
+        "null_space_min_samples": cfg.null_space_min_samples,
+        "null_space_refresh_interval": cfg.null_space_refresh_interval,
+        "train_accuracy_interval": cfg.train_accuracy_interval,
+        "train_accuracy_warmup": cfg.train_accuracy_warmup,
+        "generation_max_new_tokens": cfg.generation_max_new_tokens,
+        "output_dir": cfg.output_dir,
+    }
+
+
+def run_experiment(args: argparse.Namespace) -> None:
+    output_root = Path(args.output_root).expanduser().resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = output_root / f"{timestamp}_{args.variant}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    set_random_seeds(args.seed)
+
+    data_root = Path(args.data_root).expanduser().resolve()
+    if not data_root.exists():
+        raise FileNotFoundError(f"Data root '{data_root}' does not exist")
+
+    train_dataset = AudioCapsDataset(data_path=data_root, split=args.train_split)
+    val_audio_dataset = AudioCapsDataset(data_path=data_root, split=args.val_audio_split)
+    val_vl_dataset = VQADataset(data_path=data_root, split=args.val_vqa_split)
+
+    val_dataset = CombinedValidationDataset(
+        val_audio_dataset,
+        val_vl_dataset,
+        max_audio_samples=args.max_audio_val_samples if args.max_audio_val_samples > 0 else None,
+        max_vl_samples=args.max_vqa_val_samples if args.max_vqa_val_samples > 0 else None,
+        shuffle=not args.disable_val_shuffle,
+        seed=args.seed,
+    )
+
+    train_loader = create_safe_dataloader(
+        train_dataset,
+        batch_size=args.train_batch_size,
+        shuffle=not args.disable_train_shuffle,
+        num_workers=args.num_workers,
+    )
+    val_loader = create_safe_dataloader(
+        val_dataset,
+        batch_size=args.val_batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+    )
+
+    model_configs = {
+        "demo": DEMO_CONFIG,
+        "full": FULL_CONFIG,
+        "multimodal": MULTIMODAL_CONFIG,
+    }
+    if args.model_config not in model_configs:
+        raise ValueError(f"Unknown model config '{args.model_config}'. Options: {list(model_configs)}")
+
+    selected_model_config = model_configs[args.model_config]
+    safe_model_keys = {
+        "llm_model_name",
+        "vision_model_name",
+        "audio_encoder_type",
+        "audio_encoder_config",
+        "projector_type",
+        "num_audio_tokens",
+        "projector_config",
+        "fusion_type",
+        "fusion_layer_indices",
+        "lora_rank",
+        "fusion_config",
+        "freeze_base_vl",
+        "freeze_audio_encoder",
+        "llm_hidden_size",
+        "audio_embed_dim",
+    }
+
+    model_kwargs = {key: value for key, value in selected_model_config.items() if key in safe_model_keys}
+    model = SAFEModel(**model_kwargs)
+
+    base_config = TrainingConfig(
+        variant=args.variant,
+        seed=args.seed,
+        train_batch_size=args.train_batch_size,
+        val_batch_size=args.val_batch_size,
+        num_epochs=args.num_epochs,
+        learning_rate_projector=args.lr_projector,
+        learning_rate_adapter=args.lr_adapter,
+        fisher_weight=0.0,
+        retention_loss_weight=0.0,
+        distillation_weight=0.0,
+        enable_null_space=False,
+        null_space_rank=args.null_space_rank,
+        null_space_min_samples=args.null_space_min_samples,
+        null_space_refresh_interval=args.null_space_refresh,
+        output_dir=str(run_dir / "checkpoints"),
+        max_eval_batches=args.max_eval_batches if args.max_eval_batches > 0 else None,
+        max_audio_eval_batches=args.max_audio_eval_batches,
+        max_vl_eval_batches=args.max_vl_eval_batches,
+        eval_with_audio_gate=not args.disable_eval_audio_gate,
+        eval_audio_gate_comparison=args.eval_audio_gate_comparison,
+        eval_logging_steps=args.eval_logging_steps,
+        debug_logging=args.debug_logging,
+        train_accuracy_interval=args.train_accuracy_interval,
+        train_accuracy_warmup=args.train_accuracy_warmup,
+        train_eval_batches=args.train_eval_batches,
+        generation_max_new_tokens=args.generation_max_new_tokens,
+    )
+
+    variant_config = configure_variant(args.variant, base_config)
+    stage_a_config = build_stage_a_config(variant_config)
+
+    trainer = StageATrainer(
+        safe_model=model,
+        train_dataloader=train_loader,
+        val_dataloader=val_loader,
+        config=stage_a_config,
+        curriculum_config=None,
+    )
+
+    final_metrics = trainer.train()
+
+    train_metrics = None
+    if args.train_eval_batches > 0:
+        train_metrics = trainer.evaluate(
+            max_batches=args.train_eval_batches,
+            dataloader=train_loader,
+            description="Training",
+            split_batches=False,
+        )
+
+    config_path = run_dir / "config.json"
+    metrics_path = run_dir / "metrics.json"
+
+    with open(config_path, "w", encoding="utf-8") as fh:
+        json.dump(asdict(variant_config), fh, indent=2)
+
+    metrics_payload: Dict[str, Dict[str, float]] = {"validation": final_metrics}
+    if train_metrics is not None:
+        metrics_payload["training"] = train_metrics
+
+    with open(metrics_path, "w", encoding="utf-8") as fh:
+        json.dump(metrics_payload, fh, indent=2)
+
+    print(f"Run complete. Artefacts saved to {run_dir}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run full-scale SAFE Stage A training")
+    parser.add_argument("--variant", choices=["no_retention", "soft_retention"], help="Retention configuration")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--data-root", type=str, default="experiments/full_training/data", help="Dataset root")
+    parser.add_argument("--train-split", type=str, default="train", help="AudioCaps split for training")
+    parser.add_argument("--val-audio-split", type=str, default="val", help="AudioCaps split for validation")
+    parser.add_argument("--val-vqa-split", type=str, default="val", help="VQA split for validation")
+    parser.add_argument("--train-batch-size", type=int, default=32, help="Training batch size")
+    parser.add_argument("--val-batch-size", type=int, default=64, help="Validation batch size")
+    parser.add_argument("--num-workers", type=int, default=4, help="Dataloader worker count")
+    parser.add_argument("--num-epochs", type=int, default=10, help="Number of training epochs")
+    parser.add_argument("--lr-projector", type=float, default=2e-4, help="Learning rate for projector")
+    parser.add_argument("--lr-adapter", type=float, default=1e-4, help="Learning rate for adapter")
+    parser.add_argument("--null-space-rank", type=int, default=8, help="Null-space rank when enabled")
+    parser.add_argument("--null-space-min-samples", type=int, default=128, help="Minimum samples for null-space")
+    parser.add_argument("--null-space-refresh", type=int, default=4000, help="Null-space refresh interval")
+    parser.add_argument("--max-eval-batches", type=int, default=-1, help="Limit validation batches (<=0 = full)")
+    parser.add_argument("--max-audio-eval-batches", type=int, default=32, help="Audio eval batch cap")
+    parser.add_argument("--max-vl-eval-batches", type=int, default=64, help="VL eval batch cap")
+    parser.add_argument("--max-audio-val-samples", type=int, default=4096, help="Audio validation sample cap (<=0 disables)")
+    parser.add_argument("--max-vqa-val-samples", type=int, default=4096, help="VQA validation sample cap (<=0 disables)")
+    parser.add_argument("--eval-logging-steps", type=int, default=10, help="Eval logging frequency")
+    parser.add_argument("--train-accuracy-interval", type=int, default=0, help="Interval for train accuracy logging")
+    parser.add_argument("--train-accuracy-warmup", type=int, default=5, help="Warmup epochs before accuracy logging")
+    parser.add_argument("--train-eval-batches", type=int, default=0, help="Evaluate training split after fit")
+    parser.add_argument("--generation-max-new-tokens", type=int, default=32, help="Generation token budget")
+    parser.add_argument("--output-root", type=str, default="experiments/full_training/runs", help="Run output directory")
+    parser.add_argument("--model-config", choices=["demo", "full", "multimodal"], default="full", help="Model config preset")
+    parser.add_argument("--disable-train-shuffle", action="store_true", help="Disable shuffling for training dataloader")
+    parser.add_argument("--disable-val-shuffle", action="store_true", help="Disable shuffling when mixing validation datasets")
+    parser.add_argument("--disable-eval-audio-gate", action="store_true", help="Evaluate without audio gating")
+    parser.add_argument("--eval-audio-gate-comparison", action="store_true", help="Run with and without audio gate during eval")
+    parser.add_argument("--debug-logging", action="store_true", help="Enable verbose trainer logging")
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    run_experiment(parse_args())

--- a/scripts/full_training.sh
+++ b/scripts/full_training.sh
@@ -1,0 +1,137 @@
+#!/bin/bash -l
+
+#SBATCH --job-name="SAFE-FullTrain"
+#SBATCH --output=logs/full_training_%j.txt
+#SBATCH --error=logs/full_training_%j.err
+#SBATCH --time=72:00:00
+#SBATCH --mem=128G
+#SBATCH --cpus-per-task=16
+#SBATCH --gres=gpu:1
+#SBATCH --mail-type=FAIL,END
+#SBATCH --mail-user=rmose009@ucr.edu
+#SBATCH -p gpu
+
+set -euo pipefail
+
+if [[ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]]; then
+  source "$HOME/miniconda3/etc/profile.d/conda.sh"
+elif command -v module &>/dev/null; then
+  module load anaconda &>/dev/null || true
+  source "$HOME/.bashrc"
+fi
+
+CONDA_ENV=${CONDA_ENV:-safe-env}
+echo "Activating conda environment '${CONDA_ENV}'"
+conda activate "${CONDA_ENV}"
+
+echo "Starting SAFE full-scale training at $(date)"
+
+DATA_ROOT=${DATA_ROOT:-"$PWD/experiments/full_training/data"}
+OUTPUT_ROOT=${OUTPUT_ROOT:-"$PWD/experiments/full_training/runs/${SLURM_JOB_ID}"}
+TRAIN_SPLIT=${TRAIN_SPLIT:-train}
+VAL_AUDIO_SPLIT=${VAL_AUDIO_SPLIT:-val}
+VAL_VQA_SPLIT=${VAL_VQA_SPLIT:-val}
+NUM_EPOCHS=${NUM_EPOCHS:-10}
+TRAIN_BS=${TRAIN_BS:-32}
+VAL_BS=${VAL_BS:-64}
+NUM_WORKERS=${NUM_WORKERS:-8}
+SEED=${SEED:-42}
+MODEL_CONFIG=${MODEL_CONFIG:-full}
+LR_PROJECTOR=${LR_PROJECTOR:-2e-4}
+LR_ADAPTER=${LR_ADAPTER:-1e-4}
+NULL_SPACE_RANK=${NULL_SPACE_RANK:-8}
+NULL_SPACE_MIN_SAMPLES=${NULL_SPACE_MIN_SAMPLES:-128}
+NULL_SPACE_REFRESH=${NULL_SPACE_REFRESH:-4000}
+MAX_EVAL_BATCHES=${MAX_EVAL_BATCHES:--1}
+MAX_AUDIO_EVAL_BATCHES=${MAX_AUDIO_EVAL_BATCHES:-32}
+MAX_VL_EVAL_BATCHES=${MAX_VL_EVAL_BATCHES:-64}
+MAX_AUDIO_VAL_SAMPLES=${MAX_AUDIO_VAL_SAMPLES:-4096}
+MAX_VQA_VAL_SAMPLES=${MAX_VQA_VAL_SAMPLES:-4096}
+EVAL_LOGGING_STEPS=${EVAL_LOGGING_STEPS:-10}
+TRAIN_ACCURACY_INTERVAL=${TRAIN_ACCURACY_INTERVAL:-0}
+TRAIN_ACCURACY_WARMUP=${TRAIN_ACCURACY_WARMUP:-5}
+TRAIN_EVAL_BATCHES=${TRAIN_EVAL_BATCHES:-0}
+GEN_MAX_NEW_TOKENS=${GEN_MAX_NEW_TOKENS:-32}
+DEBUG_LOGGING=${DEBUG_LOGGING:-0}
+DISABLE_EVAL_AUDIO_GATE=${DISABLE_EVAL_AUDIO_GATE:-0}
+EVAL_AUDIO_GATE_COMPARISON=${EVAL_AUDIO_GATE_COMPARISON:-0}
+DISABLE_TRAIN_SHUFFLE=${DISABLE_TRAIN_SHUFFLE:-0}
+DISABLE_VAL_SHUFFLE=${DISABLE_VAL_SHUFFLE:-0}
+
+mkdir -p logs
+mkdir -p "$OUTPUT_ROOT"
+
+if [[ ! -d "$DATA_ROOT" ]]; then
+  echo "[ERROR] Expected data root at '$DATA_ROOT' but it was not found." >&2
+  exit 1
+fi
+
+variants=(no_retention soft_retention)
+
+debug_flag=()
+if [[ "$DEBUG_LOGGING" != "0" ]]; then
+  debug_flag+=(--debug-logging)
+fi
+
+if [[ "$DISABLE_EVAL_AUDIO_GATE" != "0" ]]; then
+  eval_gate_flag=(--disable-eval-audio-gate)
+else
+  eval_gate_flag=()
+fi
+
+if [[ "$DISABLE_TRAIN_SHUFFLE" != "0" ]]; then
+  train_shuffle_flag=(--disable-train-shuffle)
+else
+  train_shuffle_flag=()
+fi
+
+if [[ "$DISABLE_VAL_SHUFFLE" != "0" ]]; then
+  val_shuffle_flag=(--disable-val-shuffle)
+else
+  val_shuffle_flag=()
+fi
+
+eval_comparison_flag=()
+if [[ "$EVAL_AUDIO_GATE_COMPARISON" != "0" ]]; then
+  eval_comparison_flag=(--eval-audio-gate-comparison)
+fi
+
+for variant in "${variants[@]}"; do
+  echo "\n=== Running variant: ${variant} ==="
+  python -m experiments.full_training.run_full_training \
+    --variant "${variant}" \
+    --seed "${SEED}" \
+    --data-root "${DATA_ROOT}" \
+    --train-split "${TRAIN_SPLIT}" \
+    --val-audio-split "${VAL_AUDIO_SPLIT}" \
+    --val-vqa-split "${VAL_VQA_SPLIT}" \
+    --train-batch-size "${TRAIN_BS}" \
+    --val-batch-size "${VAL_BS}" \
+    --num-workers "${NUM_WORKERS}" \
+    --num-epochs "${NUM_EPOCHS}" \
+    --lr-projector "${LR_PROJECTOR}" \
+    --lr-adapter "${LR_ADAPTER}" \
+    --null-space-rank "${NULL_SPACE_RANK}" \
+    --null-space-min-samples "${NULL_SPACE_MIN_SAMPLES}" \
+    --null-space-refresh "${NULL_SPACE_REFRESH}" \
+    --max-eval-batches "${MAX_EVAL_BATCHES}" \
+    --max-audio-eval-batches "${MAX_AUDIO_EVAL_BATCHES}" \
+    --max-vl-eval-batches "${MAX_VL_EVAL_BATCHES}" \
+    --max-audio-val-samples "${MAX_AUDIO_VAL_SAMPLES}" \
+    --max-vqa-val-samples "${MAX_VQA_VAL_SAMPLES}" \
+    --eval-logging-steps "${EVAL_LOGGING_STEPS}" \
+    --train-accuracy-interval "${TRAIN_ACCURACY_INTERVAL}" \
+    --train-accuracy-warmup "${TRAIN_ACCURACY_WARMUP}" \
+    --train-eval-batches "${TRAIN_EVAL_BATCHES}" \
+    --generation-max-new-tokens "${GEN_MAX_NEW_TOKENS}" \
+    --output-root "${OUTPUT_ROOT}" \
+    --model-config "${MODEL_CONFIG}" \
+    "${debug_flag[@]}" \
+    "${eval_gate_flag[@]}" \
+    "${eval_comparison_flag[@]}" \
+    "${train_shuffle_flag[@]}" \
+    "${val_shuffle_flag[@]}"
+  echo "=== Completed variant: ${variant} ===\n"
+done
+
+echo "SAFE full-scale training sweep complete at $(date)"


### PR DESCRIPTION
## Summary
- add a new `experiments/full_training` package with documentation, data download helper, and Stage A runner for the 100x data experiment
- provide a SLURM submission script that sweeps the no-retention and soft-retention configurations for full-scale training

## Testing
- not run (cluster-only workflow / external dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d82b9a674c832a8441212e54f0068b